### PR TITLE
feat: Support GitHub PR review reporting

### DIFF
--- a/.github/workflows/ci-review.yml
+++ b/.github/workflows/ci-review.yml
@@ -1,0 +1,33 @@
+name: PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    name: Run reviewdog on PR
+    runs-on: ubuntu-latest
+    env:
+      REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Set up reviewdog
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
+        with:
+          reviewdog_version: latest
+
+      - name: Install Python dependencies
+        run: |
+          pip install ruff
+
+      - name: Run incremental review
+        run: |
+          python scripts/review.py --ci-mode -v --github
+        shell: bash


### PR DESCRIPTION
- Extend review() to accept a `--github` flag and switch reporter to `github-pr-review`
- Update CLI parser in scripts/review.py to include `--github` option
- Pass the github flag into review() invocation
- Add .github/workflows/ci-review.yml for running `review.py` on pull requests